### PR TITLE
feat: Add macOS support

### DIFF
--- a/react-native-tcp-socket.podspec
+++ b/react-native-tcp-socket.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   # s.license    = { :type => "MIT", :file => "FILE_LICENSE" }
   s.authors      = { "Rapsssito" => "contact@rodrigomartin.dev" }
-  s.platforms    = { :ios => "9.0", :tvos => "10.0" }
+  s.platforms    = { :ios => "9.0", :tvos => "10.0", :osx => "10.14" }
   s.source       = { :git => "https://github.com/Rapsssito/react-native-tcp-socket.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,swift}"


### PR DESCRIPTION
I recently needed TCPSocket support for a project running on [Microsoft's macOS version of RN](https://github.com/microsoft/react-native-macos). Everything here compiles and works just fine on macOS, the only thing needed is for the podspec to advertise that it does.