### PR TITLE
null exception error handled.

### DIFF
--- a/android/src/main/java/com/asterinet/react/tcpsocket/TcpSocketClient.java
+++ b/android/src/main/java/com/asterinet/react/tcpsocket/TcpSocketClient.java
@@ -108,6 +108,9 @@ class TcpSocketClient {
             throw new IOException("Socket is not connected.");
         }
         OutputStream output = socket.getOutputStream();
+        if (output == null ){
+            throw new IOException("OutputStream is null.");
+        }
         output.write(data);
     }
 


### PR DESCRIPTION
I don't know why (maybe related with timeout) but sometimes android throws a null exception. So I wrapped it  with a more meaningful error