### PR TITLE
fix a bug of socket.write function

### DIFF
--- a/src/Socket.js
+++ b/src/Socket.js
@@ -299,6 +299,7 @@ export default class Socket extends EventEmitter {
      */
     write(buffer, encoding, cb) {
         const self = this;
+        if (encoding && typeof encoding === 'function') cb = encoding;
         if (this._state === STATE.DISCONNECTED) throw new Error('Socket is not connected.');
 
         const generatedBuffer = this._generateSendBuffer(buffer, encoding);


### PR DESCRIPTION
hello, when call write func with default encode utf8 and callback , I think it is more convenience to only pass to params: (buffer,cb); Nodejs also did it this way.  