### PR TITLE
fix: crash on write if socket is null

### DIFF
--- a/android/src/main/java/com/asterinet/react/tcpsocket/TcpSocketClient.java
+++ b/android/src/main/java/com/asterinet/react/tcpsocket/TcpSocketClient.java
@@ -88,18 +88,20 @@ class TcpSocketClient extends TcpSocket {
      * @param data data to be sent
      */
     public void write(final int msgId, final byte[] data) {
-        writeExecutor.execute(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    socket.getOutputStream().write(data);
-                    receiverListener.onWritten(getId(), msgId, null);
-                } catch (IOException e) {
-                    receiverListener.onWritten(getId(), msgId, e.toString());
-                    receiverListener.onError(getId(), e.toString());
+        if (socket != null) {
+            writeExecutor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        socket.getOutputStream().write(data);
+                        receiverListener.onWritten(getId(), msgId, null);
+                    } catch (IOException e) {
+                        receiverListener.onWritten(getId(), msgId, e.toString());
+                        receiverListener.onError(getId(), e.toString());
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
Sends write exection only if socket is not null. This crashed the app I'm currently working on as described in this Ticket: #153 