### PR TITLE
fix: prevent iOS crash

### DIFF
--- a/src/Globals.js
+++ b/src/Globals.js
@@ -1,5 +1,4 @@
-import { NativeEventEmitter, NativeModules } from 'react-native';
-const Sockets = NativeModules.TcpSockets;
+import { NativeEventEmitter } from 'react-native';
 
 let instanceNumber = 0;
 
@@ -7,6 +6,9 @@ function getNextId() {
     return instanceNumber++;
 }
 
-const nativeEventEmitter = new NativeEventEmitter(Sockets);
+const nativeEventEmitter = new NativeEventEmitter({
+    addListener: () => null,
+    removeListeners: () => null,
+});
 
 export { nativeEventEmitter, getNextId };


### PR DESCRIPTION
Starting from Expo 45 `NativeEventEmitter` requires params to be defined explicitly. Otherwise, it is crashing with

<img width="663" alt="image" src="https://user-images.githubusercontent.com/23197387/186146642-dc9e0e05-9eb2-4e9f-a731-da55fddeae21.png">
