### PR TITLE
fix crash for ios when localPort or connectedPort is null

### DIFF
--- a/ios/TcpSocketClient.m
+++ b/ios/TcpSocketClient.m
@@ -137,9 +137,6 @@ NSString *const RCTTCPErrorDomain = @"RCTTCPErrorDomain";
         _certPath = certResourcePath;
         [settings setObject:[NSNumber numberWithBool:YES]
                      forKey:GCDAsyncSocketManuallyEvaluateTrust];
-    } else {
-        // Default certificates
-        [settings setObject:_host forKey:(NSString *)kCFStreamSSLPeerName];
     }
     _tls = true;
     [_tcpSocket startTLS:settings];

--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -185,20 +185,23 @@ RCT_EXPORT_METHOD(resume : (nonnull NSNumber *)cId) {
 
 - (void)onConnect:(TcpSocketClient *)client {
     GCDAsyncSocket *socket = [client getSocket];
-    [self sendEventWithName:@"connect"
-                       body:@{
-                           @"id" : client.id,
-                           @"connection" : @{
-                               @"localAddress" : [socket localHost],
-                               @"localPort" :
-                                   [NSNumber numberWithInt:[socket localPort]],
-                               @"remoteAddress" : [socket connectedHost],
-                               @"remotePort" : [NSNumber
-                                   numberWithInt:[socket connectedPort]],
-                               @"remoteFamily" : [socket isIPv4] ? @"IPv4"
-                                                                 : @"IPv6"
-                           }
-                       }];
+    if([socket localPort] != nil && [socket connectedPort] != nil) {
+        [self sendEventWithName:@"connect"
+                           body:@{
+                               @"id" : client.id,
+                               @"connection" : @{
+                                   @"localAddress" : [socket localHost],
+                                   @"localPort" :
+                                       [NSNumber numberWithInt:[socket localPort]],
+                                   @"remoteAddress" : [socket connectedHost],
+                                   @"remotePort" : [NSNumber
+                                       numberWithInt:[socket connectedPort]],
+                                   @"remoteFamily" : [socket isIPv4] ? @"IPv4"
+                                                                     : @"IPv6"
+                               }
+                           }];
+    }
+   
 }
 
 - (void)onListen:(TcpSocketClient *)server {

--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -185,7 +185,8 @@ RCT_EXPORT_METHOD(resume : (nonnull NSNumber *)cId) {
 
 - (void)onConnect:(TcpSocketClient *)client {
     GCDAsyncSocket *socket = [client getSocket];
-    if([socket localPort] != nil && [socket connectedPort] != nil) {
+    if([socket localHost] != nil && [socket connectedHost] != nil && [socket localPort] != nil
+       && [socket connectedPort] != nil) {
         [self sendEventWithName:@"connect"
                            body:@{
                                @"id" : client.id,

--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -200,6 +200,10 @@ RCT_EXPORT_METHOD(resume : (nonnull NSNumber *)cId) {
                                                                      : @"IPv6"
                                }
                            }];
+    } else {
+         NSString *msg =
+            [NSString stringWithFormat:@"no client found with id %@", client.id];
+        [self sendEventWithName:@"error" body:@{@"id" : client.id, @"error" : msg}];
     }
    
 }


### PR DESCRIPTION
<img width="533" alt="image" src="https://user-images.githubusercontent.com/111419070/215932206-4a73ec45-6db5-4c12-aa19-2decf575f5ec.png">
<img width="813" alt="image" src="https://user-images.githubusercontent.com/111419070/215932266-1256029a-e05f-4482-aab9-a4b39c064445.png">

It will send an error event when connectedPort or localPort is null