### PR TITLE
fix: Allow client.write() when pending

### DIFF
--- a/src/Socket.js
+++ b/src/Socket.js
@@ -328,7 +328,11 @@ export default class Socket extends EventEmitter {
      */
     write(buffer, encoding, cb) {
         const self = this;
-        if (this._pending || this._destroyed) throw new Error('Socket is closed.');
+        if (this._destroyed) throw new Error('Socket is closed.');
+        if (this._pending) {
+            this.once('connect', () => this.write(buffer, encoding, cb));
+            return false;
+        }
 
         const generatedBuffer = this._generateSendBuffer(buffer, encoding);
         this._writeBufferSize += generatedBuffer.byteLength;


### PR DESCRIPTION
Thanks for this library. I've tried to use it with another library which essentially does:

```
const net = require("net");
const client = net.createConnection({ port: 1883, host: "example.com" });
client.write("Hello, server!");
```

The above code works in node without raising an error, but in this library it throws the `'Socket is closed.'` error. This change resolves the issue and queues up the writes until the socket connects.