### PR TITLE
fix: Upgrade bouncycastle dependency to 1.78.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,6 +17,6 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     // Bouncy Castle dependencies
-    implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
-    implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
+    implementation 'org.bouncycastle:bcprov-jdk15to18:1.78.1'
+    implementation 'org.bouncycastle:bcpkix-jdk15to18:1.78.1'
 }


### PR DESCRIPTION
This update adresses using this package in conjunction with `expo-updates` in Expo 52. We update the dependency to match the newer version.

This PR fixes #199 