### PR TITLE
feat(iOS): Add more NodeJS TLS options

### DIFF
--- a/android/src/main/java/com/asterinet/react/tcpsocket/SSLCertificateHelper.java
+++ b/android/src/main/java/com/asterinet/react/tcpsocket/SSLCertificateHelper.java
@@ -80,6 +80,30 @@ final class SSLCertificateHelper {
         return sslContext.getServerSocketFactory();
     }
 
+    static boolean hasIdentity(ReadableMap options) {
+        boolean hasId = false;
+        try {
+            final String keystoreName = options.hasKey("androidKeyStore") ?
+                    options.getString("androidKeyStore") : KeyStore.getDefaultType();
+            final String keyAlias = options.hasKey("keyAlias") ?
+                    options.getString("keyAlias") : "";
+
+            if (keyAlias.isEmpty()) {
+                return false;
+            }
+
+            // Get keystore instance
+            KeyStore keyStore = KeyStore.getInstance(keystoreName);
+            keyStore.load(null, null);
+
+            // Check if key entry exists with its certificate chain
+            hasId = keyStore.isKeyEntry(keyAlias);
+            return hasId;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+    
     public static PrivateKey getPrivateKeyFromPEM(InputStream keyStream) {
         try (PemReader pemReader = new PemReader(new InputStreamReader(keyStream))) {
             PemObject pemObject = pemReader.readPemObject();

--- a/android/src/main/java/com/asterinet/react/tcpsocket/TcpSocketClient.java
+++ b/android/src/main/java/com/asterinet/react/tcpsocket/TcpSocketClient.java
@@ -87,9 +87,13 @@ class TcpSocketClient extends TcpSocket {
         }
         return false;
     }
+
     private ResolvableOption getResolvableOption(ReadableMap tlsOptions, String key) {
         if (tlsOptions.hasKey(key)) {
             String value = tlsOptions.getString(key);
+            if (value == null || value.isEmpty()) {
+                return null;
+            }
             ReadableArray resolvedKeys = tlsOptions.hasKey("resolvedKeys") ? tlsOptions.getArray("resolvedKeys") : null;
             boolean needsResolution = resolvedKeys != null && containsKey(resolvedKeys, key);
             return new ResolvableOption(value, needsResolution);
@@ -110,7 +114,8 @@ class TcpSocketClient extends TcpSocket {
         final KeystoreInfo keystoreInfo = new KeystoreInfo(keystoreName, caAlias, certAlias, keyAlias);
 
         if (tlsOptions.hasKey("rejectUnauthorized") && !tlsOptions.getBoolean("rejectUnauthorized")) {
-            if (customTlsKey != null && customTlsCert != null ) {
+            if ((customTlsKey != null && customTlsCert != null) ||
+                    (keyAlias != null && !keyAlias.isEmpty() && customTlsKey == null) ) {
                 ssf = SSLCertificateHelper.createCustomTrustedSocketFactory(
                         context,
                         customTlsCa,

--- a/android/src/main/java/com/asterinet/react/tcpsocket/TcpSocketModule.java
+++ b/android/src/main/java/com/asterinet/react/tcpsocket/TcpSocketModule.java
@@ -386,6 +386,16 @@ public class TcpSocketModule extends ReactContextBaseJavaModule {
 
     @SuppressWarnings("unused")
     @ReactMethod
+    public void hasIdentity(@NonNull final ReadableMap options, Promise promise) {
+        try {
+            promise.resolve(SSLCertificateHelper.hasIdentity(options));
+        } catch (Exception e) {
+            promise.reject(e);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @ReactMethod
     public void getPeerCertificate(final int cId, Promise promise) {
         try {
             final TcpSocketClient client = getTcpClient(cId);

--- a/ios/TcpSocketClient.h
+++ b/ios/TcpSocketClient.h
@@ -19,6 +19,18 @@ typedef enum RCTTCPError RCTTCPError;
 
 @class TcpSocketClient;
 
+// Add ResolvableOption interface here
+@interface ResolvableOption : NSObject
+
+@property (nonatomic, strong, readonly) NSString *value;
+@property (nonatomic, readonly) BOOL needsResolution;
+
+- (instancetype)initWithValue:(NSString *)value needsResolution:(BOOL)needsResolution;
++ (instancetype)optionWithValue:(NSString *)value needsResolution:(BOOL)needsResolution;
+- (NSString *)resolve;
+
+@end
+
 @protocol SocketClientDelegate <NSObject>
 
 - (void)addClient:(TcpSocketClient *)client;

--- a/ios/TcpSocketClient.h
+++ b/ios/TcpSocketClient.h
@@ -127,4 +127,16 @@ typedef enum RCTTCPError RCTTCPError;
 
 - (void)resume;
 
+/**
+ * Get peer certificate information
+ * @return NSDictionary with certificate information or nil if not available
+ */
+- (NSDictionary *)getPeerCertificate;
+
+/**
+ * Get local certificate information
+ * @return NSDictionary with certificate information or nil if not available
+ */
+- (NSDictionary *)getCertificate;
+
 @end

--- a/ios/TcpSocketClient.h
+++ b/ios/TcpSocketClient.h
@@ -127,6 +127,8 @@ typedef enum RCTTCPError RCTTCPError;
 
 - (void)resume;
 
++ (BOOL)hasIdentity:(NSDictionary *)aliases;
+
 /**
  * Get peer certificate information
  * @return NSDictionary with certificate information or nil if not available

--- a/ios/TcpSocketClient.m
+++ b/ios/TcpSocketClient.m
@@ -122,17 +122,6 @@ NSString *const RCTTCPErrorDomain = @"RCTTCPErrorDomain";
     return self;
 }
 
-- (void)dealloc {
-    if (_clientIdentity) {
-        CFRelease(_clientIdentity);
-        _clientIdentity = NULL;
-    }
-    if (_peerTrust) {
-        CFRelease(_peerTrust);
-        _peerTrust = NULL;
-    }
-}
-
 - (BOOL)connect:(NSString *)host
            port:(int)port
     withOptions:(NSDictionary *)options

--- a/ios/TcpSocketClient.m
+++ b/ios/TcpSocketClient.m
@@ -229,11 +229,6 @@ NSString *const RCTTCPErrorDomain = @"RCTTCPErrorDomain";
         //RCTLogWarn(@"startTLS: Attempting client certificate authentication");
         NSString *pemCert = [resolvableCert resolve];
         NSString *pemKey = [resolvableKey resolve];
-
-//        RCTLogWarn(
-//                   @"startTLS: Resolved PEM cert exists: %@, PEM key exists: %@",
-//                   pemCert ? @"YES" : @"NO", pemKey ? @"YES" : @"NO");
-
         if (pemCert && pemKey) {
             myIdent = [self createIdentityWithCert:pemCert
                                         privateKey:pemKey
@@ -705,8 +700,6 @@ typedef NS_ENUM(NSInteger, PEMType) {
 - (SecIdentityRef)createIdentityWithCert:(NSString *)pemCert
                               privateKey:(NSString *)pemKey
                                 settings:(NSDictionary *)settings {
-    RCTLogWarn(@"createIdentity: Starting identity creation");
-
     OSStatus status = -1;
     SecIdentityRef identity = NULL;
 
@@ -732,7 +725,8 @@ typedef NS_ENUM(NSInteger, PEMType) {
     // Import certificate in keychain
     NSDictionary *deleteCertQuery = @{
         (__bridge id)kSecClass : (__bridge id)kSecClassCertificate,
-        (__bridge id)kSecAttrLabel: certAlias
+        (__bridge id)kSecAttrLabel: certAlias,
+        (__bridge id)kSecReturnRef : @YES
     };
     status = SecItemDelete((__bridge CFDictionaryRef)deleteCertQuery);
 
@@ -751,8 +745,7 @@ typedef NS_ENUM(NSInteger, PEMType) {
                                     
     NSDictionary *privateKeyAttributes = @{
         (__bridge id)kSecAttrKeyType : (__bridge id)kSecAttrKeyTypeRSA,
-        (__bridge id)kSecAttrKeyClass : (__bridge id)kSecAttrKeyClassPrivate,
-        //(__bridge id)kSecReturnPersistentRef : @YES
+        (__bridge id)kSecAttrKeyClass : (__bridge id)kSecAttrKeyClassPrivate
     };
     CFErrorRef error = NULL;
     SecKeyRef privateKey = SecKeyCreateWithData(
@@ -768,8 +761,8 @@ typedef NS_ENUM(NSInteger, PEMType) {
 
     NSDictionary *deleteKeyQuery = @{
         (__bridge id)kSecClass : (__bridge id)kSecClassKey,
-        //(__bridge id)kSecAttrKeyType : (__bridge id)kSecAttrKeyTypeRSA,
-        (__bridge id)kSecAttrLabel: keyAlias
+        (__bridge id)kSecAttrLabel: keyAlias,
+        (__bridge id)kSecReturnRef : @YES
     };
     status = SecItemDelete((__bridge CFDictionaryRef)deleteKeyQuery);
 
@@ -798,8 +791,6 @@ typedef NS_ENUM(NSInteger, PEMType) {
     if (status != errSecSuccess || !identity) {
         RCTLogWarn(@"createIdentity: Failed to find identity, status: %d",
                    (int)status);
-    } else {
-        RCTLogWarn(@"createIdentity: Successfully found identity");
     }
     
     // Clean up

--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -175,6 +175,14 @@ RCT_EXPORT_METHOD(resume : (nonnull NSNumber *)cId) {
     [client resume];
 }
 
+RCT_EXPORT_METHOD(hasIdentity:(nonnull NSDictionary *)aliases
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    // Since this is a static check of the keychain, we don't need a client instance
+    BOOL hasIdentity = [TcpSocketClient hasIdentity:aliases];
+    resolve(@(hasIdentity));
+}
+
 RCT_EXPORT_METHOD(getPeerCertificate:(nonnull NSNumber *)cId
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {

--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -175,6 +175,35 @@ RCT_EXPORT_METHOD(resume : (nonnull NSNumber *)cId) {
     [client resume];
 }
 
+// Method with Promise (modern style)
+RCT_EXPORT_METHOD(getPeerCertificate:(nonnull NSNumber *)cId
+                  detailed:(BOOL)detailed
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    TcpSocketClient *client = [self findClient:cId];
+    if (!client) {
+        reject(@"NOT_FOUND", @"Client not found", nil);
+        return;
+    }
+    
+    NSDictionary *cert = [client getPeerCertificate:detailed];
+    resolve(cert ?: [NSNull null]);
+}
+
+RCT_EXPORT_METHOD(getCertificate:(nonnull NSNumber *)cId
+                  detailed:(BOOL)detailed
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    TcpSocketClient *client = [self findClient:cId];
+    if (!client) {
+        reject(@"NOT_FOUND", @"Client not found", nil);
+        return;
+    }
+    
+    NSDictionary *cert = [client getCertificate:detailed];
+    resolve(cert ?: [NSNull null]);
+}
+
 - (void)onWrittenData:(TcpSocketClient *)client msgId:(NSNumber *)msgId {
     [self sendEventWithName:@"written"
                        body:@{

--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -175,9 +175,7 @@ RCT_EXPORT_METHOD(resume : (nonnull NSNumber *)cId) {
     [client resume];
 }
 
-// Method with Promise (modern style)
 RCT_EXPORT_METHOD(getPeerCertificate:(nonnull NSNumber *)cId
-                  detailed:(BOOL)detailed
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     TcpSocketClient *client = [self findClient:cId];
@@ -186,12 +184,11 @@ RCT_EXPORT_METHOD(getPeerCertificate:(nonnull NSNumber *)cId
         return;
     }
     
-    NSDictionary *cert = [client getPeerCertificate:detailed];
+    NSDictionary *cert = [client getPeerCertificate];
     resolve(cert ?: [NSNull null]);
 }
 
 RCT_EXPORT_METHOD(getCertificate:(nonnull NSNumber *)cId
-                  detailed:(BOOL)detailed
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     TcpSocketClient *client = [self findClient:cId];
@@ -200,7 +197,7 @@ RCT_EXPORT_METHOD(getCertificate:(nonnull NSNumber *)cId
         return;
     }
     
-    NSDictionary *cert = [client getCertificate:detailed];
+    NSDictionary *cert = [client getCertificate];
     resolve(cert ?: [NSNull null]);
 }
 

--- a/lib/types/Socket.d.ts
+++ b/lib/types/Socket.d.ts
@@ -119,9 +119,8 @@ export default class Socket extends EventEmitter<SocketEvents & ReadableEvents, 
     setTimeout(timeout: number, callback?: (() => void) | undefined): Socket;
     /**
      * @private
-     * @param {number} [timeout]
      */
-    private _activateTimer;
+    private _resetTimeout;
     /**
      * @private
      */

--- a/lib/types/TLSSocket.d.ts
+++ b/lib/types/TLSSocket.d.ts
@@ -12,6 +12,19 @@
  */
 export default class TLSSocket extends Socket {
     /**
+     * Checks if a certificate identity exists in the keychain
+     * @param {object} options Object containing the identity aliases
+     * @param {string} [options.androidKeyStore] The android keystore type
+     * @param {string} [options.certAlias] The certificate alias
+     * @param {string} [options.keyAlias] The key alias
+     * @returns {Promise<boolean>} Promise resolving to true if identity exists
+     */
+    static hasIdentity(options?: {
+        androidKeyStore: string | undefined;
+        certAlias: string | undefined;
+        keyAlias: string | undefined;
+    }): Promise<boolean>;
+    /**
      * @private
      * Resolves the asset source if necessary and registers the resolved key.
      * @param {TLSSocketOptions} options The options object containing the source to be resolved.

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -11,6 +11,7 @@ declare namespace _default {
     export { Socket };
     export { TLSServer };
     export { TLSSocket };
+    export const hasIdentity: typeof import("./TLSSocket").default.hasIdentity;
 }
 export default _default;
 /**

--- a/src/TLSSocket.js
+++ b/src/TLSSocket.js
@@ -66,6 +66,20 @@ export default class TLSSocket extends Socket {
         Sockets.startTLS(this._id, this._options);
     }
 
+    /**
+     * Checks if a certificate identity exists in the keychain
+     * @param {object} options Object containing the identity aliases
+     * @param {string} [options.certAlias] The certificate alias
+     * @param {string} [options.keyAlias] The key alias
+     * @returns {Promise<boolean>} Promise resolving to true if identity exists
+     */
+    static hasIdentity(options = {}) {
+        return Sockets.hasIdentity({
+            certAlias: options.certAlias,
+            keyAlias: options.keyAlias
+        });
+    }
+
     getCertificate() {
         return Sockets.getCertificate(this._id);
     }

--- a/src/TLSSocket.js
+++ b/src/TLSSocket.js
@@ -69,14 +69,16 @@ export default class TLSSocket extends Socket {
     /**
      * Checks if a certificate identity exists in the keychain
      * @param {object} options Object containing the identity aliases
+     * @param {string} [options.androidKeyStore] The android keystore type
      * @param {string} [options.certAlias] The certificate alias
      * @param {string} [options.keyAlias] The key alias
      * @returns {Promise<boolean>} Promise resolving to true if identity exists
      */
     static hasIdentity(options = {}) {
         return Sockets.hasIdentity({
+            androidKeyStore: options.androidKeyStore,
             certAlias: options.certAlias,
-            keyAlias: options.keyAlias
+            keyAlias: options.keyAlias,
         });
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -112,6 +112,7 @@ export default {
     Socket,
     TLSServer,
     TLSSocket,
+    hasIdentity: TLSSocket.hasIdentity,
 };
 
 // @ts-ignore
@@ -128,4 +129,5 @@ module.exports = {
     Socket,
     TLSServer,
     TLSSocket,
+    hasIdentity: TLSSocket.hasIdentity,
 };


### PR DESCRIPTION
Hi,
As I already did for the android part here is the last part for iOS that allows to pass a digital identity(cert + private key) that will be used during TLS client authentication.
I implemented this because I am working on a react-native-androidtv-remote and it was mandatory.

So basically for a client to authenticate it can pass a cert/key either as a pem string or directly as a file:

```
const options = {
  port: port,
  host: '127.0.0.1',
  androidKeyStore: 'AndroidKeyStore'
  cert: require('client-cert.pem'),
  key: require('client-key.pem'),
  certAlias: 'myCert',
  keyAlias: 'myKey',
};
```

or 
```
const cert = `
-----BEGIN CERTIFICATE-----
MII.......
-----END CERTIFICATE-----`;

const key= `
-----BEGIN PRIVATE KEY-----
MII.......
-----END PRIVATE KEY-----`;
`
const options = {
  port: port,
  host: '127.0.0.1',
  androidKeyStore: 'AndroidKeyStore'
  cert: cert,
  key: key,
  certAlias: 'myCert',
  keyAlias: 'myKey',
};
```

I have implemented getPeerCertificate() and getCertificate() but since on iOS there is no ASN1 decoder that can be easily used I have only implemented the fields I was interested in ie:
-exponent
-modulus
-pubkey
-subject/CN
-issuer/CN

if some people needs more fields a solution is to add the libder library (https://github.com/Apple-FOSS-Mirror/CommonCrypto/tree/master/Source/libDER) and to use it to decode all fields as in the node implementation.
One drawback of not using a proper asn1 decoder is the fact that on iOS we can only insert keys of 2048 bits when using key in PKCS8 format (-----BEGIN PRIVATE KEY-----), if you need to use another key length you can use PKCS1 format (-----BEGIN RSA PRIVATE KEY-----).

If you provide a cert/key with it's corresponding alias you can then check if the digital identity has been inserted inside the keystore through TLS.hasIdentity and in this case for the next connection if you only provide certAlias/keyAlias without the key/cert then it will take the certificate directly from the keystore without having to insert it everytime.
Please not that on Android when you do not provide the androidKeyStore key, the certificate/key will not be stored permanentlty (only in memory). Maybe later it could be interesting to use  AndroidKeyStore to have the same behavior as iOS by default.

Finally I have also include a fix about timeout because it was fixing my timeout issues.
