### PR TITLE
fix: Fix createServer() to properly handle Node.js-compatible options parameter

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,4 +1,5 @@
 import { expect, test } from '@jest/globals';
+
 import net from '../src/index';
 
 test('create-client', () => {
@@ -11,14 +12,35 @@ test('create-client', () => {
         // interface: "wifi"
     };
 
-    const socket = net.createConnection(options, () => {});
+    const socket = net.createConnection(options, () => { });
     expect(socket).toBeInstanceOf(net.Socket);
 });
 
 test('create-server', () => {
-    const server = net.createServer(() => {});
+    const server = net.createServer(() => { });
     expect(server).toBeInstanceOf(net.Server);
 });
+
+test('create-server-with-options', () => {
+    const server = net.createServer({
+        noDelay: true,
+        keepAlive: true
+    }, () => {
+        console.info('server started')
+    });
+    expect(server).toBeInstanceOf(net.Server);
+});
+
+test('create-server-options-no-calback', () => {
+    const server = net.createServer({
+        noDelay: true,
+        keepAlive: true
+    });
+    server.on('connection', () => {
+        console.info('connection received');
+    });
+});
+
 
 test('isIP', () => {
     expect(net.isIP('127.9.8.9')).toBe(4);

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -18,18 +18,38 @@ export default _default;
  * @param {() => void} callback
  * @returns {Socket}
  */
-declare function createConnection(options: import('./Socket').ConnectionOptions, callback: () => void): Socket;
+declare function createConnection(
+    options: import('./Socket').ConnectionOptions,
+    callback: () => void
+): Socket;
 /**
- * @param {(socket: Socket) => void} connectionListener
+ * @typedef {object} ServerOptions
+ * @property {boolean} [noDelay]
+ * @property {boolean} [keepAlive]
+ * @property {number} [keepAliveInitialDelay]
+ * @property {boolean} [allowHalfOpen]
+ * @property {boolean} [pauseOnConnect]
+ */
+
+/**
+ * @param {ServerOptions | ((socket: Socket) => void)} [options]
+ * @param {(socket: Socket) => void} [connectionListener]
  * @returns {Server}
  */
-declare function createServer(connectionListener: (socket: Socket) => void): Server;
+declare function createServer(
+    options?: object | ((socket: Socket) => void),
+    connectionListener?: (socket: Socket) => void
+): Server;
+
 /**
  * @param {import('./TLSServer').TLSServerOptions} options
  * @param {(socket: TLSSocket) => void} connectionListener
  * @returns {TLSServer}
  */
-declare function createTLSServer(options: import('./TLSServer').TLSServerOptions, connectionListener: (socket: TLSSocket) => void): TLSServer;
+declare function createTLSServer(
+    options: import('./TLSServer').TLSServerOptions,
+    connectionListener: (socket: TLSSocket) => void
+): TLSServer;
 /**
  * The `callback` function, if specified, will be added as a listener for the `'secureConnect'` event.
  *
@@ -37,7 +57,10 @@ declare function createTLSServer(options: import('./TLSServer').TLSServerOptions
  * @param {() => void} [callback]
  * @returns {TLSSocket}
  */
-declare function connectTLS(options: import('./TLSSocket').TLSSocketOptions & import('./Socket').ConnectionOptions, callback?: (() => void) | undefined): TLSSocket;
+declare function connectTLS(
+    options: import('./TLSSocket').TLSSocketOptions & import('./Socket').ConnectionOptions,
+    callback?: (() => void) | undefined
+): TLSSocket;
 /**
  * Tests if input is an IP address. Returns `0` for invalid strings, returns `4` for IP version 4 addresses, and returns `6` for IP version 6 addresses.
  *
@@ -56,7 +79,7 @@ declare function isIPv4(input: string): boolean;
  * @param {string} input
  */
 declare function isIPv6(input: string): boolean;
-import Server from "./Server";
-import Socket from "./Socket";
-import TLSServer from "./TLSServer";
-import TLSSocket from "./TLSSocket";
+import Server from './Server';
+import Socket from './Socket';
+import TLSServer from './TLSServer';
+import TLSSocket from './TLSSocket';

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,28 @@
 'use strict';
 
-import Socket from './Socket';
 import Server from './Server';
+import Socket from './Socket';
 import TLSServer from './TLSServer';
 import TLSSocket from './TLSSocket';
 
 /**
- * @param {(socket: Socket) => void} connectionListener
+ * @typedef {object} ServerOptions
+ * @property {boolean} [noDelay]
+ * @property {boolean} [keepAlive]
+ * @property {number} [keepAliveInitialDelay]
+ * @property {boolean} [allowHalfOpen]
+ * @property {boolean} [pauseOnConnect]
+ */
+
+/**
+ * Creates a new TCP server.
+ * 
+ * @param {ServerOptions | ((socket: Socket) => void)} [options] An options object or a connection listener
+ * @param {(socket: Socket) => void} [connectionListener] A listener for the 'connection' event
  * @returns {Server}
  */
-function createServer(connectionListener) {
-    return new Server(connectionListener);
+function createServer(options, connectionListener) {
+    return new Server(options, connectionListener);
 }
 
 /**


### PR DESCRIPTION
## Fix createServer to properly handle Node.js-compatible options parameter

fix #183 fix #209
## Issue

Currently, when using `createServer` with options similar to Node.js, it causes a TypeError:

```javascript
// This works with no issues
const server = net.connect({
  noDelay: true,
  keepAlive: true
}, () => {
  console.info('server started')
})

// This causes TypeError: The listener must be a function
const server = net.createServer({
  noDelay: true,
  keepAlive: true
}, () => {
  console.info('server started')
})
```

The signature of `createServer` needs to be consistent with Node.js, where options can be passed as the first argument.

## Changes

This PR implements:

1. Updated `Server.js` constructor to properly handle options vs. connectionListener arguments
2. Added proper `ServerOptions` type definition with support for:
   - `noDelay`
   - `keepAlive`
   - `keepAliveInitialDelay`
   - `allowHalfOpen`
   - `pauseOnConnect`
3. Enhanced the `listen()` method to match Node.js signature patterns:
   - `listen(port, [host], [callback])`
   - `listen(options, [callback])`
4. Fixed TypeScript definitions to correctly type all parameters and eliminate type errors
5. Added `_applySocketOptions` method to apply server options to new socket connections

## Testing

The following patterns now work without errors:

```javascript
// With options and listener
const server1 = net.createServer({
  noDelay: true,
  keepAlive: true
}, () => {
  console.info('server started')
});

// Just with listener
const server2 = net.createServer(() => {
  console.info('connection received')
});

// Setting options with just the object
const server3 = net.createServer({
  noDelay: true,
  keepAlive: true
});
server3.on('connection', () => {
  console.info('connection received');
});
```

These changes improve compatibility with code written for Node.js and make the library more intuitive to use for developers familiar with the Node.js API.