### PR TITLE
feat: implement allowHalfOpen and end event for libp2p compatibility

### DIFF
--- a/android/src/main/java/com/asterinet/react/tcpsocket/TcpEventListener.java
+++ b/android/src/main/java/com/asterinet/react/tcpsocket/TcpEventListener.java
@@ -117,6 +117,12 @@ public class TcpEventListener {
         sendEvent("close", eventParams);
     }
 
+    public void onEnd(int id) {
+        WritableMap eventParams = Arguments.createMap();
+        eventParams.putInt("id", id);
+        sendEvent("end", eventParams);
+    }
+
     public void onError(int id, Exception e) {
         Log.e(TcpSocketModule.TAG, "Exception on socket " + id, e);
         String error = e.getMessage();

--- a/android/src/main/java/com/asterinet/react/tcpsocket/TcpSocketClient.java
+++ b/android/src/main/java/com/asterinet/react/tcpsocket/TcpSocketClient.java
@@ -255,7 +255,8 @@ class TcpSocketClient extends TcpSocket {
                     if (bufferCount > 0) {
                         receiverListener.onData(socketId, Arrays.copyOfRange(buffer, 0, bufferCount));
                     } else if (bufferCount == -1) {
-                        clientSocket.destroy();
+                        receiverListener.onEnd(socketId);
+                        break;
                     }
                 }
             } catch (IOException | InterruptedException ioe) {

--- a/ios/TcpSocketClient.h
+++ b/ios/TcpSocketClient.h
@@ -43,6 +43,7 @@ typedef enum RCTTCPError RCTTCPError;
 - (void)onClose:(TcpSocketClient *)client withError:(NSError *)err;
 - (void)onError:(TcpSocketClient *)client withError:(NSError *)err;
 - (void)onWrittenData:(TcpSocketClient *)client msgId:(NSNumber *)msgId;
+- (void)onEnd:(NSNumber *)clientID;
 - (NSNumber *)getNextId;
 
 @end

--- a/ios/TcpSocketClient.m
+++ b/ios/TcpSocketClient.m
@@ -579,9 +579,8 @@ NSString *const RCTTCPErrorDomain = @"RCTTCPErrorDomain";
 }
 
 - (void)socketDidCloseReadStream:(GCDAsyncSocket *)sock {
-    // TODO : investigate for half-closed sockets
-    // for now close the stream completely
-    [sock disconnect];
+    // Half-closed socket support
+    [_clientDelegate onEnd:_id];
 }
 
 - (void)socketDidDisconnect:(GCDAsyncSocket *)sock withError:(NSError *)err {

--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -22,7 +22,7 @@ RCT_EXPORT_MODULE()
 - (NSArray<NSString *> *)supportedEvents {
     return @[
         @"connect", @"listening", @"connection", @"secureConnection", @"data",
-        @"close", @"error", @"written"
+        @"close", @"error", @"written", @"end"
     ];
 }
 
@@ -214,6 +214,13 @@ RCT_EXPORT_METHOD(getCertificate:(nonnull NSNumber *)cId
                        body:@{
                            @"id" : client.id,
                            @"msgId" : msgId,
+                       }];
+}
+
+- (void)onEnd:(NSNumber *)clientID {
+    [self sendEventWithName:@"end"
+                       body:@{
+                           @"id" : clientID
                        }];
 }
 

--- a/src/Server.js
+++ b/src/Server.js
@@ -249,6 +249,10 @@ export default class Server extends EventEmitter {
                 const keepAliveDelay = this._serverOptions.keepAliveInitialDelay || 0;
                 newSocket.setKeepAlive(this._serverOptions.keepAlive, keepAliveDelay);
             }
+
+            if (this._serverOptions.allowHalfOpen !== undefined) {
+                newSocket.allowHalfOpen = this._serverOptions.allowHalfOpen;
+            }
         }
 
         return newSocket;


### PR DESCRIPTION
Hey! This update fixes the UnexpectedEOFError that was breaking libp2p connections.
What was happening
When using this library with js-libp2p, the connection would fail during the encryption handshake. After checking the logs, I found that libp2p expects sockets to support “half-open” mode (where reading can stop but writing can continue).
This library was closing the entire socket as soon as it got a FIN packet, which caused the error.
What I changed
I added support for allowHalfOpen and made the socket behave more like Node’s net module. -JavaScript
Added an allowHalfOpen option to Socket (defaults to false).
Added an event listener for when the read side closes.
Instead of destroying the socket, it now switches to a readOnly state.-Android
Updated TcpSocketClient to emit an onEnd() event when EOF is detected instead of calling destroy() immediately. iOS Implemented the missing onEnd delegate method. Now it sends an event to JS when the read side closes instead of disconnecting right away.
Testing-
Tested using @abuvanth’s reproduction repo (react-native-libp2p-tcp-test). Before this fix, the connection would fail instantly. After the changes, the handshake completes without issues.

