### PR TITLE
Fix crash when localPort or connectedPort is nil (new)

### DIFF
--- a/ios/TcpSockets.m
+++ b/ios/TcpSockets.m
@@ -219,20 +219,23 @@ RCT_EXPORT_METHOD(getCertificate:(nonnull NSNumber *)cId
 
 - (void)onConnect:(TcpSocketClient *)client {
     GCDAsyncSocket *socket = [client getSocket];
-    [self sendEventWithName:@"connect"
-                       body:@{
-                           @"id" : client.id,
-                           @"connection" : @{
-                               @"localAddress" : [socket localHost],
-                               @"localPort" :
-                                   [NSNumber numberWithInt:[socket localPort]],
-                               @"remoteAddress" : [socket connectedHost],
-                               @"remotePort" : [NSNumber
-                                   numberWithInt:[socket connectedPort]],
-                               @"remoteFamily" : [socket isIPv4] ? @"IPv4"
-                                                                 : @"IPv6"
-                           }
-                       }];
+    if([socket localPort] != nil && [socket connectedPort] != nil) {
+        [self sendEventWithName:@"connect"
+                           body:@{
+                               @"id" : client.id,
+                               @"connection" : @{
+                                   @"localAddress" : [socket localHost],
+                                   @"localPort" :
+                                       [NSNumber numberWithInt:[socket localPort]],
+                                   @"remoteAddress" : [socket connectedHost],
+                                   @"remotePort" : [NSNumber
+                                       numberWithInt:[socket connectedPort]],
+                                   @"remoteFamily" : [socket isIPv4] ? @"IPv4"
+                                                                     : @"IPv6"
+                               }
+                           }];
+    }
+   
 }
 
 - (void)onListen:(TcpSocketClient *)server {


### PR DESCRIPTION
Implemented fix recommended [here](https://github.com/Rapsssito/react-native-tcp-socket/pull/172#issuecomment-2924424006) by @Rapsssito 